### PR TITLE
Implement the flush_all command.

### DIFF
--- a/lib/Client.cpp
+++ b/lib/Client.cpp
@@ -481,6 +481,43 @@ bool Client::getStats(char **pName, size_t *cbName, char **pArg, size_t *cbArg)
 }
 
 
+bool Client::flushAll(time_t *expiration, bool async)
+{
+  m_writer.writeChars("flush_all ", 9);
+
+  if (expiration)
+  {
+    m_writer.writeChar(' ');
+    m_writer.writeNumeric(*expiration);
+  }
+
+  if (async)
+  {
+    m_writer.writeChars(" noreply", 8);
+  }
+
+  m_writer.writeChars("\r\n", 2);
+
+  if (!sendWriteBuffer())
+  {
+    return false;
+  }
+
+  if (async)
+  {
+    return true;
+  }
+
+  if (!readLine())
+  {
+    return false;
+  }
+
+  return true;
+}
+
+
+
 bool Client::getReadNext(char **key, size_t *cbKey, char **data, size_t *cbData, int *_flags, UINT64 *_cas, bool *bError)
 {
   *bError = false;

--- a/lib/Client.h
+++ b/lib/Client.h
@@ -86,6 +86,7 @@ public:
   bool version(char **version, size_t *cbVersion);
   bool stats(const char *arg, size_t cbArg);
   bool getStats(char **pName, size_t *cbName, char **pArg, size_t *cbArg);
+  bool flushAll(time_t *expiration, bool async);
   bool getResult(char **pData, size_t *cbSize);
   const char *getError(void);
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -337,6 +337,14 @@ class Testumemcache(unittest.TestCase):
 
         c.disconnect();
         pass
+
+    def testFlushAll(self):
+        c = Client(MEMCACHED_ADDRESS);
+        c.connect();
+        c.set("key1", "31337")
+        self.assertEquals(c.get("key1")[0], "31337")
+        c.flush_all()
+        self.assertEquals(c.get("key1"), None)
     
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is useful e.g. during testing to clear any junk data from the cache.
