### PR TITLE
Use forward slashes in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,6 @@
-include tests\*.py
+include tests/*.py
 include README
-include python\*.cpp
-include python\*.c
-include python\*.h
-include lib\*.cpp
-include lib\*.c
-include lib\*.h
+include python/*.cpp
+include python/*.h
+include lib/*.cpp
+include lib/*.h


### PR DESCRIPTION
According to the docs, MANIFEST.in should use forward slashes for all paths and the tools will internally convert them to whatever is appropriate for the current platform:

   http://docs.python.org/distutils/sourcedist.html#manifest-template

This fixes MANIFEST.in to use forward slashes, which lets it work better with build tools like pypi2rpm.
