### PR TITLE
modify u_int* to uint* to build on solaris

### DIFF
--- a/lib/mcdefs.h
+++ b/lib/mcdefs.h
@@ -36,8 +36,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <windows.h>
 #else
 #include <sys/types.h>
-typedef u_int64_t UINT64;
-typedef u_int8_t UINT8;
+#include <stdint.h>
+typedef uint64_t UINT64;
+typedef uint8_t UINT8;
 #endif
 
 #endif


### PR DESCRIPTION
stdint.h definition is added as well, since type size_t is provided by sys/types.h. it is the same type of modification for ultrajson.

already tested on linux, OS X and solaris.
