### PR TITLE
Fixed a potential memory leak

### DIFF
--- a/lib/PacketReader.cpp
+++ b/lib/PacketReader.cpp
@@ -50,7 +50,7 @@ PacketReader::PacketReader (size_t _cbSize)
 
 PacketReader::~PacketReader (void)
 {
-  delete m_buffStart;
+  delete[] m_buffStart;
 }
 
 void PacketReader::skip()

--- a/lib/PacketWriter.cpp
+++ b/lib/PacketWriter.cpp
@@ -48,7 +48,7 @@ PacketWriter::PacketWriter(size_t _cbSize)
 
 PacketWriter::~PacketWriter(void)
 {
-  delete m_buffStart;
+  delete[] m_buffStart;
 }
 
 // Push/increment write cursor


### PR DESCRIPTION
PacketReader & PacketWriter did not correctly cleanup the buffer
m_buffStart in the dtor.
