### PR TITLE
Support item size larger than 1024*1200 bytes

### DIFF
--- a/lib/Client.cpp
+++ b/lib/Client.cpp
@@ -38,9 +38,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //#define PRINTMARK() fprintf(stderr, "%s: MARK(%d)\n", __FILE__, __LINE__)		
 #define PRINTMARK() 		
 
-Client::Client (SOCKETDESC *sockdesc) 
-  :	m_writer (1024 * 1200)
-  , m_reader (1024 * 1200)
+Client::Client (SOCKETDESC *sockdesc, size_t maxSize) 
+  :	m_writer (maxSize)
+  , m_reader (maxSize)
 {
   m_sock = sockdesc;
 }

--- a/lib/Client.h
+++ b/lib/Client.h
@@ -59,7 +59,7 @@ public:
 public:
 
 
-  Client (SOCKETDESC *sockdesc);
+  Client (SOCKETDESC *sockdesc, size_t maxSize);
   ~Client (void);
   bool connect(const char *address, int port);
   bool isConnected(void);

--- a/python/umemcache.cpp
+++ b/python/umemcache.cpp
@@ -285,7 +285,7 @@ int Client_init(PyClient *self, PyObject *args, PyObject *kwargs)
   self->desc.recv = API_recv;
   self->desc.send = API_send;
   PRINTMARK();
-  self->client = new Client(&self->desc);
+  self->client = new Client(&self->desc, self->maxSize);
   PRINTMARK();
 
   return 0;


### PR DESCRIPTION
Fix an issue when setting max_item_size to 10MB and sending at most 2.3MB. Used to receive a segmentation fault on python process. FreeBSD.