### PR TITLE
Fix GCC warning about non-const format string

### DIFF
--- a/python/umemcache.cpp
+++ b/python/umemcache.cpp
@@ -819,7 +819,7 @@ PyObject *Client_incr(PyClient *self, PyObject *args)
 
       if (strncmp (pResult, "CLIENT_ERROR", 12) == 0)
       {
-        return PyErr_Format(umemcache_MemcachedError, pResult);
+        return PyErr_Format(umemcache_MemcachedError, "%s", pResult);
       }
 
       return PyString_FromStringAndSize(pResult, cbResult);
@@ -867,7 +867,7 @@ PyObject *Client_decr(PyClient *self, PyObject *args)
 
       if (strncmp (pResult, "CLIENT_ERROR", 12) == 0)
       {
-        return PyErr_Format(umemcache_MemcachedError, pResult);
+        return PyErr_Format(umemcache_MemcachedError, "%s", pResult);
       }
 
       return PyString_FromStringAndSize(pResult, cbResult);


### PR DESCRIPTION
This could be a vulnerability, as the string returned by getResult seems to be entirely chosen by the network, and the strncmp only checks the string starts with CLIENT_ERROR, opening way to format string vulns. Being new to this codebase, I would however not assert it is a vulnerability without trying to exploit it, and do not have any time to try and do it right now, so this is only a (strong, in my opinion) possibility.

This patch keeps the hopefully intended behaviour, eliminating the possibility for pResult to contain %-escapes.